### PR TITLE
elma365: bump to 2025.4.1

### DIFF
--- a/elma365-appsets/apps/elma365/chart-version.yaml
+++ b/elma365-appsets/apps/elma365/chart-version.yaml
@@ -3,4 +3,4 @@ kind: ConfigMap
 metadata:
   name: elma365-version
 data:
-  version: "2025.4.0"
+  version: "2025.4.1"


### PR DESCRIPTION
This PR updates elma365 chart to version `2025.4.1`.